### PR TITLE
fixes clearing the timeout (cache.close())

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,12 @@ myCache.getStats();
   */
 ```
 
+## Close the cache:
+`myCache.close()`
+
+This will clear the interval timeout which is set on checkperiod option.
+
+
 # Events
 
 ## set

--- a/lib/node_cache.js
+++ b/lib/node_cache.js
@@ -120,6 +120,10 @@
       return delCount;
     };
 
+    NodeCache.prototype.close = function() {
+      this._killCheckPeriod();
+    };
+
     NodeCache.prototype.ttl = function() {
       var arg, args, cb, key, ttl, _i, _len;
       key = arguments[0], args = 2 <= arguments.length ? __slice.call(arguments, 1) : [];


### PR DESCRIPTION
when setting checkperiod in options.