### PR TITLE
Add key prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ var myCache = new NodeCache();
 ```
 
 ### Options
-
-- `stdTTL`: *(default: `0`)* the standard ttl as number in seconds for every generated cache element.  
+- `prefix`: *(default: `""`) The prefix to use when setting keys in the cache.
+- `stdTTL`: *(default: `0`)* The standard ttl as number in seconds for every generated cache element.  
 `0` = unlimited
 - `checkperiod`: *(default: `600`)* The period in seconds, as a number, used for the automatic delete check interval.  
 `0` = no periodic check.  
-**Note:** If you use `checkperiod > 0` you script will not exit at the end, because a internal timeout will always be active.
+**Note:** If you use `checkperiod > 0` your script will not exit at the end, because an internal timeout will always be active.
 
 ```js
 var NodeCache = require( "node-cache" );

--- a/lib/node_cache.js
+++ b/lib/node_cache.js
@@ -36,7 +36,8 @@
         objectValueSize: 80,
         arrayValueSize: 40,
         stdTTL: 0,
-        checkperiod: 600
+        checkperiod: 600,
+        prefix: ''
       }, this.options);
       this.stats = {
         hits: 0,
@@ -50,9 +51,9 @@
 
     NodeCache.prototype.get = function(key, cb) {
       var _ret;
-      if ((this.data[key] != null) && this._check(key, this.data[key])) {
+      if ((this.data[this.options.prefix+key] != null) && this._check(key, this.data[this.options.prefix+key])) {
         this.stats.hits++;
-        _ret = this._unwrap(this.data[key]);
+        _ret = this._unwrap(this.data[this.options.prefix+key]);
         if (cb != null) {
           cb(null, _ret);
         }
@@ -78,9 +79,9 @@
       oRet = {};
       for (i = 0, len = keys.length; i < len; i++) {
         key = keys[i];
-        if ((this.data[key] != null) && this._check(key, this.data[key])) {
+        if ((this.data[this.options.prefix+key] != null) && this._check(key, this.data[this.options.prefix+key])) {
           this.stats.hits++;
-          oRet[key] = this._unwrap(this.data[key]);
+          oRet[key] = this._unwrap(this.data[this.options.prefix+key]);
         } else {
           this.stats.misses++;
         }
@@ -101,11 +102,11 @@
         cb = ttl;
         ttl = this.options.stdTTL;
       }
-      if (this.data[key]) {
+      if (this.data[this.options.prefix+key]) {
         existend = true;
-        this.stats.vsize -= this._getValLength(this._unwrap(this.data[key]));
+        this.stats.vsize -= this._getValLength(this._unwrap(this.data[this.options.prefix+key]));
       }
-      this.data[key] = this._wrap(value, ttl);
+      this.data[this.options.prefix+key] = this._wrap(value, ttl);
       this.stats.vsize += this._getValLength(value);
       if (!existend) {
         this.stats.ksize += this._getKeyLength(key);
@@ -126,13 +127,13 @@
       delCount = 0;
       for (i = 0, len = keys.length; i < len; i++) {
         key = keys[i];
-        if (this.data[key] != null) {
-          this.stats.vsize -= this._getValLength(this._unwrap(this.data[key]));
+        if (this.data[this.options.prefix+key] != null) {
+          this.stats.vsize -= this._getValLength(this._unwrap(this.data[this.options.prefix+key]));
           this.stats.ksize -= this._getKeyLength(key);
           this.stats.keys--;
           delCount++;
-          oldVal = this.data[key];
-          delete this.data[key];
+          oldVal = this.data[this.options.prefix+key];
+          delete this.data[this.options.prefix+key];
           this.emit("del", key, oldVal.v);
         } else {
           this.stats.misses++;
@@ -164,9 +165,9 @@
         }
         return false;
       }
-      if ((this.data[key] != null) && this._check(key, this.data[key])) {
+      if ((this.data[this.options.prefix+key] != null) && this._check(key, this.data[this.options.prefix+key])) {
         if (ttl > 0) {
-          this.data[key] = this._wrap(this.data[key].v, ttl);
+          this.data[this.options.prefix+key] = this._wrap(this.data[this.options.prefix+key].v, ttl);
         } else {
           this.del(key);
         }
@@ -185,6 +186,11 @@
     NodeCache.prototype.keys = function(cb) {
       var _keys;
       _keys = Object.keys(this.data);
+      if(this.options.prefix != "") {
+        for(var i=0;i<_keys.length;i++) {
+          _keys[i] = _keys[i].split(this.options.prefix)[1];
+        }
+      }
       if (cb != null) {
         cb(null, _keys);
       }
@@ -277,7 +283,7 @@
     };
 
     NodeCache.prototype._getKeyLength = function(key) {
-      return key.length;
+      return (this.options.prefix+key).length;
     };
 
     NodeCache.prototype._getValLength = function(value) {

--- a/test/node_cache-test.js
+++ b/test/node_cache-test.js
@@ -15,6 +15,11 @@
     checkperiod: 0
   });
 
+  localCachePrefix = new VCache({
+    prefix: "test-prefix:",
+    checkperiod: 0
+  });
+
   localCache._killCheckPeriod();
 
   randomString = function(length, withnumbers) {
@@ -494,6 +499,32 @@
             localCacheTTL._checkData(false);
             assert.isUndefined(localCacheTTL.data[key5]);
           }, 500);
+        });
+      });
+    },
+    "prefix": function(beforeExit, assert) {
+      var key = "my-test-key";
+      var value = "My test value";
+      console.log("\nSTART PREFIX TEST\n");
+      localCachePrefix.set(key, value, function(err, res) {
+        assert.isNull(err, err);
+        assert.equal(1, localCachePrefix.getStats().keys);
+        localCachePrefix.get(key, function(err, res) {
+          assert.eql(value, res);
+        });
+        localCachePrefix.keys(function(err, res) {
+          var pred;
+          pred = [key];
+          assert.eql(pred, res);
+          localCachePrefix.del(key, function(err, res) {
+            assert.isNull(err, err);
+            assert.equal(1, res);
+            localCachePrefix.keys(function(err, res) {
+              var pred;
+              pred = [];
+              assert.eql(pred, res);
+            });
+          });
         });
       });
     }


### PR DESCRIPTION
I added an option to prepend a prefix to every key. 

The tests all pass, and I added a case to test with a store set up with a prefix.

Performance-wise, when the option is not set, there is no impact (at least, not noticeable in milliseconds) to get requests, and there is maybe a 1 - 2% impact when setting keys. When the option is set, get operations jump from 25ms for 100k to around 100ms for 100k. Set jump from 200ms to around 280ms.

This should not be a problem, since most people won't use the option anyway.

I also added the option to the README.