### PR TITLE
unref() the checkperiod timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ var myCache = new NodeCache();
 - `stdTTL`: *(default: `0`)* the standard ttl as number in seconds for every generated cache element.  
 `0` = unlimited
 - `checkperiod`: *(default: `600`)* The period in seconds, as a number, used for the automatic delete check interval.  
-`0` = no periodic check.  
-**Note:** If you use `checkperiod > 0` you script will not exit at the end, because an internal timeout will always be active.
+`0` = no periodic check.
 - `useClones`: *(default: `true`)* en/disable cloning of variables. If `true` you'll get a copy of the cached variable. If `false` you'll save and get just the reference.  
 **Note:** `true` is recommended, because it'll behave like a server-based caching. You should set `false` if you want to save complex variable types like functions, promises, regexp, ...
 

--- a/_src/lib/node_cache.coffee
+++ b/_src/lib/node_cache.coffee
@@ -362,6 +362,7 @@ module.exports = class NodeCache extends EventEmitter
 		
 		if startPeriod and @options.checkperiod > 0
 			@checkTimeout = setTimeout( @_checkData, ( @options.checkperiod * 1000 ) )
+			@checkTimeout.unref()
 		return
 	
 	# ## _killCheckPeriod

--- a/lib/node_cache.js
+++ b/lib/node_cache.js
@@ -229,6 +229,7 @@
       }
       if (startPeriod && this.options.checkperiod > 0) {
         this.checkTimeout = setTimeout(this._checkData, this.options.checkperiod * 1000);
+        this.checkTimeout.unref();
       }
     };
 


### PR DESCRIPTION
This should prevent the process staying alive problem and no longer encourages people to use `process.exit`.