### PR TITLE
Adding 'has' method

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,28 @@ value = myCache.mget( [ "myKeyA", "myKeyB" ] );
 
 The method for mget changed from `.get( [ "a", "b" ] )` to `.mget( [ "a", "b" ] )`
 
+## Check if a key exists (HAS)
+
+`myCache.has ( key, [callback] )`
+
+Determines if the key is set in the cache.
+Returns true if the value is found, or false if the value was not set or has expired.
+
+```js
+myCache.set("myKey", "test value");
+myCache.has("myKey", function( err, value ) {
+  if ( !err ){
+    console.log( value );
+    /*
+      true
+    */
+  }
+});
+```
+
+**Since `3.0.2`**:
+Method added at version 3.0.2
+
 ## Delete a key (DEL):
 
 `myCache.del( key, [callback] )`

--- a/_src/lib/node_cache.coffee
+++ b/_src/lib/node_cache.coffee
@@ -35,6 +35,25 @@ module.exports = class NodeCache extends EventEmitter
 		# initalize checking period
 		@_checkData()
 
+	# ## has
+	#
+	# determines if a key has been set yet
+	#
+	# **Parameters:**
+	#
+	# * `key` ( String ): cache key
+	# * `[cb]` ( Function ): Callback function
+	#
+	# **Example:**
+	#
+	#     myCache.has "myKey", ( err, exists )->
+	#       console.log( err, exists )
+	#
+	has: ( key, cb )=>
+		exists = !! @data[ key ] and @_check( key, @data[ key ] )
+		cb( null, exists ) if cb?
+		return exists
+
 	# ## get
 	#
 	# get a cached key and change the stats

--- a/_src/test/node_cache-test.coffee
+++ b/_src/test/node_cache-test.coffee
@@ -42,6 +42,8 @@ module.exports =
 		value2 = randomString( 100 )
 		key = randomString( 10 )
 
+		aKeyThatDoesNotExist = randomString( 10 )
+
 
 		localCache.once "del", ( _key, _val )->
 			assert.equal( _key, key )
@@ -62,6 +64,18 @@ module.exports =
 				n++
 				# generate a predicted value
 				assert.eql value, res
+				return
+
+			# make sure exists
+			localCache.has key, ( err, exists )->
+				n++
+				assert.eql( true, exists )
+				return
+
+			# make sure missing key does not exist
+			localCache.has aKeyThatDoesNotExist, ( err, exists )->
+				n++
+				assert.eql( false, exists )
 				return
 
 			# try to get
@@ -157,7 +171,7 @@ module.exports =
 			console.log "No Promise test, because not availible in this node version"
 
 		beforeExit ->
-			_count = 11
+			_count = 13
 			if Promise?
 				_count += 1
 			

--- a/lib/node_cache.js
+++ b/lib/node_cache.js
@@ -30,6 +30,7 @@
       this.set = bind(this.set, this);
       this.mget = bind(this.mget, this);
       this.get = bind(this.get, this);
+      this.has = bind(this.has, this);
       this.data = {};
       this.options = _.extend({
         forceString: false,
@@ -48,6 +49,15 @@
       };
       this._checkData();
     }
+
+    NodeCache.prototype.has = function(key, cb) {
+      var exists;
+      exists = !!this.data[key] && this._check(key, this.data[key]);
+      if (cb != null) {
+        cb(null, exists);
+      }
+      return exists;
+    };
 
     NodeCache.prototype.get = function(key, cb) {
       var _ret;

--- a/test/node_cache-test.js
+++ b/test/node_cache-test.js
@@ -49,13 +49,14 @@
 
   module.exports = {
     "general": function(beforeExit, assert) {
-      var _err, key, n, p, q, start, value, value2;
+      var _err, aKeyThatDoesNotExist, key, n, p, q, start, value, value2;
       console.log("\nSTART GENERAL TEST: " + VCache.version);
       n = 0;
       start = _.clone(localCache.getStats());
       value = randomString(100);
       value2 = randomString(100);
       key = randomString(10);
+      aKeyThatDoesNotExist = randomString(10);
       localCache.once("del", function(_key, _val) {
         assert.equal(_key, key);
         assert.equal(_val, value2);
@@ -67,6 +68,14 @@
         localCache.get(key, function(err, res) {
           n++;
           assert.eql(value, res);
+        });
+        localCache.has(key, function(err, exists) {
+          n++;
+          assert.eql(true, exists);
+        });
+        localCache.has(aKeyThatDoesNotExist, function(err, exists) {
+          n++;
+          assert.eql(false, exists);
         });
         localCache.keys(function(err, res) {
           var pred;
@@ -142,7 +151,7 @@
       }
       beforeExit(function() {
         var _count;
-        _count = 11;
+        _count = 13;
         if (typeof Promise !== "undefined" && Promise !== null) {
           _count += 1;
         }


### PR DESCRIPTION
Adding  the `.has` method, used to ensure a key is available, to handle cases where `.set("key", foo.bar)` might result in a falsy value. EG:

```js
function loadPreferencesForModule( moduleName ) {
    var key = "arbitraryPrefixString:" + moduleName;
    if ( ! myCache.has(key) ) {
        var promise = 
            fetchDataFromSomewhereQuiteSlow()
                .then( extractAKeyFromTheDataThatMightBeMissing );
                .then( function ( value ) {
                    return myCache.set(key, value);
                });
    } else {
        return new Promise(function(resolve, reject) {
            resolve( myCache.get(key) );
        });
    }
}
```

- so if we fetched a preferences object with `fetchDataFromSomewhereQuiteSlow`, then extracted the preferences for a module that hasn't had any preferences set yet, the correct value would be `undefined`. Rather than wait for the preferences to load every time we want to know about this module's preferences, we would want to avoid the call over the network and just return `undefined` until the cached value expires.

( If this is merged, please be aware I have assumed the next version is **3.0.2** in the `README.md` file. )