### PR TITLE
Adding `throwOnMissing` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ var myCache = new NodeCache();
 `0` = unlimited
 - `checkperiod`: *(default: `600`)* The period in seconds, as a number, used for the automatic delete check interval.  
 `0` = no periodic check.
+- `throwOnMissing`: *(default: `false`)* en/disable throwing or passing an error to the callback if attempting to `.get` a missing or expired value.
 - `useClones`: *(default: `true`)* en/disable cloning of variables. If `true` you'll get a copy of the cached variable. If `false` you'll save and get just the reference.  
 **Note:** `true` is recommended, because it'll behave like a server-based caching. You should set `false` if you want to save complex variable types like functions, promises, regexp, ...
 
@@ -45,6 +46,9 @@ var myCache = new NodeCache();
 var NodeCache = require( "node-cache" );
 var myCache = new NodeCache( { stdTTL: 100, checkperiod: 120 } );
 ```
+
+**Since `3.0.2`**
+`throwOnMissing` option added
 
 ## Store a key (SET):
 

--- a/_src/lib/node_cache.coffee
+++ b/_src/lib/node_cache.coffee
@@ -69,10 +69,11 @@ module.exports = class NodeCache extends EventEmitter
 			# if not found return a error
 			@stats.misses++
 			if @options.throwOnMissing or throwOnMissing
+				missingError = new Error("Missing key " + key)
 				if cb
-					cb( new Error("Missing key " + key), undefined )
+					cb( missingError, undefined )
 				else
-					throw new Error("Missing key " + key);
+					throw missingError;
 			else
 				cb( null, undefined ) if cb?
 			return undefined

--- a/_src/test/node_cache-test.coffee
+++ b/_src/test/node_cache-test.coffee
@@ -77,7 +77,30 @@ module.exports =
 				assert.isNull( err, err )
 				assert.isUndefined( res, res )
 				return
-			
+
+			# catch an undefined key
+			errorHandlerCallback = ( err, res )->
+				n++
+				assert.eql( err.message, "Missing key xxx" )
+				return
+			localCache.get "xxx", errorHandlerCallback, true
+
+			# catch an undefined key without callback
+			try
+				localCache.get("xxx", true)
+			catch error
+				n++
+				assert.eql( error.message, "Missing key xxx" )
+
+			# throwOnMissing option triggers throwing error automatically
+			originalThrowOnMissingValue = localCache.options.throwOnMissing;
+			try
+				localCache.options.throwOnMissing = true
+				localCache.get("xxx")
+			catch error
+				n++
+				assert.eql( error.message, "Missing key xxx" )
+			localCache.options.throwOnMissing = originalThrowOnMissingValue;
 
 			# try to delete an undefined key
 			localCache.del "xxx", ( err, res )->
@@ -157,7 +180,7 @@ module.exports =
 			console.log "No Promise test, because not availible in this node version"
 
 		beforeExit ->
-			_count = 11
+			_count = 14
 			if Promise?
 				_count += 1
 			

--- a/lib/node_cache.js
+++ b/lib/node_cache.js
@@ -37,7 +37,8 @@
         arrayValueSize: 40,
         stdTTL: 0,
         checkperiod: 600,
-        useClones: true
+        useClones: true,
+        throwOnMissing: false
       }, this.options);
       this.stats = {
         hits: 0,
@@ -49,8 +50,12 @@
       this._checkData();
     }
 
-    NodeCache.prototype.get = function(key, cb) {
+    NodeCache.prototype.get = function(key, cb, throwOnMissing) {
       var _ret;
+      if (typeof cb === "boolean" && arguments.length === 2) {
+        throwOnMissing = cb;
+        cb = void 0;
+      }
       if ((this.data[key] != null) && this._check(key, this.data[key])) {
         this.stats.hits++;
         _ret = this._unwrap(this.data[key]);
@@ -60,8 +65,16 @@
         return _ret;
       } else {
         this.stats.misses++;
-        if (cb != null) {
-          cb(null, void 0);
+        if (this.options.throwOnMissing || throwOnMissing) {
+          if (cb) {
+            cb(new Error("Missing key " + key), void 0);
+          } else {
+            throw new Error("Missing key " + key);
+          }
+        } else {
+          if (cb != null) {
+            cb(null, void 0);
+          }
         }
         return void 0;
       }

--- a/test/node_cache-test.js
+++ b/test/node_cache-test.js
@@ -61,6 +61,7 @@
         assert.equal(_val, value2);
       });
       localCache.set(key, value, 0, function(err, res) {
+        var error, errorHandlerCallback, originalThrowOnMissingValue;
         assert.isNull(err, err);
         n++;
         assert.equal(1, localCache.getStats().keys - start.keys);
@@ -79,6 +80,28 @@
           assert.isNull(err, err);
           assert.isUndefined(res, res);
         });
+        errorHandlerCallback = function(err, res) {
+          n++;
+          assert.eql(err.message, "Missing key xxx");
+        };
+        localCache.get("xxx", errorHandlerCallback, true);
+        try {
+          localCache.get("xxx", true);
+        } catch (_error) {
+          error = _error;
+          n++;
+          assert.eql(error.message, "Missing key xxx");
+        }
+        originalThrowOnMissingValue = localCache.options.throwOnMissing;
+        try {
+          localCache.options.throwOnMissing = true;
+          localCache.get("xxx");
+        } catch (_error) {
+          error = _error;
+          n++;
+          assert.eql(error.message, "Missing key xxx");
+        }
+        localCache.options.throwOnMissing = originalThrowOnMissingValue;
         localCache.del("xxx", function(err, res) {
           n++;
           assert.isNull(err, err);
@@ -142,7 +165,7 @@
       }
       beforeExit(function() {
         var _count;
-        _count = 11;
+        _count = 14;
         if (typeof Promise !== "undefined" && Promise !== null) {
           _count += 1;
         }


### PR DESCRIPTION
In the case where you _really do want_ to store `undefined`, when you call `.get` you cannot tell the difference between "i am passing you undefined because the value is not set yet" and "I am passing you undefined because you set the value to undefined earlier". 

In cases where calculating the correct value for a key is slow, you would end up not caching properly.

Adding the `throwOnMissing` option allows the caller to handle the error properly:

```js
myCache = new NodeCache({ throwOnMissing: true });

new Promise(function(resolve, reject) {
    resolve(myCache.get("some key"));
    // throws! rejects the promise, causes the `.catch` to run
})
    .catch(function() {
        // in this case we don't care why it failed, we just need to calculate the value
        return myCache.set("some key", expensiveSlowFunctionToCalculateTheValue(), 60);
    })
    .then(function(theValue) {
        // Great! We have the value we need, either from the slow external service,
        // or from the cache; this `.then` block doesn't need to care which :)
    })
```